### PR TITLE
Fix 'No Access-Control-Allow-Origin header set' error on streaming/server.js

### DIFF
--- a/streaming/count.html
+++ b/streaming/count.html
@@ -37,7 +37,7 @@
     </div>
     <script src="/socket.io/socket.io.js"></script>
     <script>
-      var socket = io.connect('http://localhost');
+      var socket = io.connect();
       var count = 0;
       var now, start = new Date();
       var tps = 0;

--- a/streaming/custom.html
+++ b/streaming/custom.html
@@ -175,7 +175,7 @@
     <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
     <script src="/socket.io/socket.io.js"></script>
     <script>
-      var socket = io.connect('http://localhost');
+      var socket = io.connect();
       var tweets = [];
       var tweetIndex = -1;
       var timelineId = 'custom-401517619594805248';


### PR DESCRIPTION
Deleted socketio.connect url parameter, to avoid 'No Access-Control-Allow-Origin header set' error
